### PR TITLE
Add Flask API scaffold with Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # MoStar-Initiative
+
+## API Server
+
+A simple Flask server is provided under the `api/` directory. It uses the
+`AkanimoIniobong-mo-star_ai_api-1.0.0-swagger.json` specification to define
+available endpoints and exposes interactive documentation.
+
+### Setup
+
+```bash
+pip install -r requirements.txt
+python api/app.py
+```
+
+The server runs on `http://localhost:5000` with Swagger UI available at
+`http://localhost:5000/docs`.

--- a/api/AkanimoIniobong-mo-star_ai_api-1.0.0-swagger.json
+++ b/api/AkanimoIniobong-mo-star_ai_api-1.0.0-swagger.json
@@ -1,0 +1,57 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Mo-Star AI API",
+    "version": "1.0.0"
+  },
+  "basePath": "/",
+  "schemes": ["http"],
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "Service is up",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict": {
+      "post": {
+        "summary": "Generate a placeholder AI response",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "prompt": {"type": "string"}
+              },
+              "required": ["prompt"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated response",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "response": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,31 @@
+from flask import Flask, jsonify, request
+from flasgger import Swagger
+
+app = Flask(__name__)
+swagger_config = {
+    "swagger_ui": True,
+    "specs_route": "/docs"
+}
+swagger = Swagger(
+    app,
+    template_file="AkanimoIniobong-mo-star_ai_api-1.0.0-swagger.json",
+    config=swagger_config,
+)
+
+@app.route("/", methods=["GET"])
+def health():
+    """Health check endpoint"""
+    return jsonify({"message": "Service is up"})
+
+
+@app.route("/predict", methods=["POST"])
+def predict():
+    """Generate placeholder response based on provided prompt."""
+    data = request.get_json() or {}
+    prompt = data.get("prompt", "")
+    response_text = prompt[::-1]
+    return jsonify({"response": response_text})
+
+
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+flasgger


### PR DESCRIPTION
## Summary
- scaffold Flask server under `api/`
- load `AkanimoIniobong-mo-star_ai_api-1.0.0-swagger.json` and expose Swagger UI at `/docs`
- document setup steps in README and add requirements file

## Testing
- `python -m py_compile api/app.py`
- `pytest` (no tests collected)


------
https://chatgpt.com/codex/tasks/task_e_6894e9a0dcf883248e44dbf6cf4541e0