### PR TITLE
Add demo route, landing page scaffold, and deployment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # MoStar-Initiative
+
+## API Server
+
+A simple Flask server is provided under the `api/` directory. It uses the
+`MoStarIndustries-api-1.0.0-swagger.json` specification to define
+available endpoints and exposes interactive documentation.
+
+### Setup
+
+```bash
+pip install -r requirements.txt
+python api/app.py
+```
+
+The server runs on `http://localhost:5000` with Swagger UI available at
+`http://localhost:5000/docs`.
+
+### Demo Route
+
+An example endpoint illustrates climate anomaly prediction:
+
+```
+GET /demo/climate
+```
+
+This returns a sample JSON prediction payload.
+
+### Landing Page
+
+A minimal Vite site lives under `platform/` and can be used as a landing page
+or future web client.
+
+```bash
+cd platform
+npm install
+npm run dev
+```
+
+The development server defaults to `http://localhost:5173`.
+
+### Deploying to Render
+
+A basic `render.yaml` is included for deployment.
+
+```bash
+render.yaml
+```
+
+This configuration installs requirements and runs the API using `gunicorn` on
+Render's free plan.

--- a/api/MoStarIndustries-api-1.0.0-swagger.json
+++ b/api/MoStarIndustries-api-1.0.0-swagger.json
@@ -1,0 +1,86 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "MoStar Industries API",
+    "description": "Core API specification for MoStar's federated intelligence and smart systems.",
+    "version": "1.0.0"
+  },
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "Service is up",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict": {
+      "post": {
+        "summary": "Generate a placeholder AI response",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "prompt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "prompt"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated response",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "response": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/demo/climate": {
+      "get": {
+        "summary": "Demo climate anomaly prediction",
+        "responses": {
+          "200": {
+            "description": "Sample anomaly prediction",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "prediction": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, jsonify, request
+from flasgger import Swagger
+
+app = Flask(__name__)
+swagger_config = {
+    "swagger_ui": True,
+    "specs_route": "/docs"
+}
+swagger = Swagger(
+    app,
+    template_file="MoStarIndustries-api-1.0.0-swagger.json",
+    config=swagger_config,
+)
+
+@app.route("/", methods=["GET"])
+def health():
+    """Health check endpoint"""
+    return jsonify({"message": "Service is up"})
+
+
+@app.route("/predict", methods=["POST"])
+def predict():
+    """Generate placeholder response based on provided prompt."""
+    data = request.get_json() or {}
+    prompt = data.get("prompt", "")
+    response_text = prompt[::-1]
+    return jsonify({"response": response_text})
+
+
+@app.route("/demo/climate", methods=["GET"])
+def demo_climate():
+    """Return a sample climate anomaly prediction."""
+    return jsonify({"prediction": "No anomaly detected"})
+
+
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/platform/index.html
+++ b/platform/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MoStar Industries</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mostar-platform",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/platform/src/main.js
+++ b/platform/src/main.js
@@ -1,0 +1,3 @@
+const app = document.getElementById('app');
+app.innerHTML = `<h1>MoStar Industries Platform</h1>
+<p>Building modular intelligence with AI and blockchain.</p>`;

--- a/platform/vite.config.js
+++ b/platform/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    port: 5173,
+  },
+})

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: mostar-api
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn api.app:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+flasgger
+gunicorn


### PR DESCRIPTION
## Summary
- add `/demo/climate` route and describe it in Swagger spec
- scaffold Vite landing page under `platform/`
- provide `render.yaml` and include `gunicorn` for deployment

## Testing
- `python -m py_compile api/app.py && echo 'py_compile success'`
- `pytest`
- `npm --version`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9a0dcf883248e44dbf6cf4541e0